### PR TITLE
added readme example context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ HyperFuel supports a json api mainly for debugging.  It's recommended to use the
 - [node js client](https://github.com/enviodev/hyperfuel-client-node)
 
 # Example curl query
+In this example, we query from blocks 0 (inclusive) to 1300000 (exclusive) for all `Inputs` where the address `0x2a0d0ed9d2217ec7f32dcd9a1902ce2a66d68437aeff84e3a3cc8bebee0d2eea` matches on an input's `asset_id` field.
+
 Paste the example curl request into your terminal!
 ```bash
 curl --request POST \


### PR DESCRIPTION
Added description for the README's example query (same query as `asset-id-query-example`)

closes #3 